### PR TITLE
fixed: 'Check out Squares.' button link

### DIFF
--- a/source/rawjs/RawJs.ts
+++ b/source/rawjs/RawJs.ts
@@ -78,7 +78,7 @@ page("/rawjs", "RawJS: Make document.createElement() Great Again",
 		space(100),
 		button.blue(
 			"Check out Squares.", 
-			"https://github.com/squaresapp/rawjs-sample"),
+			"https://www.squaresapp.org/"),
 		
 		space(200),
 	),


### PR DESCRIPTION
**Issue:** `Check out Squares.` button incorrectly links to [rawjs-sample](https://github.com/squaresapp/rawjs-sample) project. Updated to link to [www.squaresapp.org](https://www.squaresapp.org/).

Closes [this issue](https://github.com/squaresapp/rawjs/issues/4).